### PR TITLE
Fix wrong array instantiation syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ make it easy to create managed arrays from Python:
 ```python
 from System import Array
 
-myarray = Array[int](10)
+myarray = Array[int](range(10))
 ```
 
 Managed arrays support the standard Python sequence protocols:


### PR DESCRIPTION
Otherwise it throws `TypeError: Cannot convert 10 to System.Int32[]`

Documented in https://github.com/pythonnet/pythonnet/issues/788 and https://github.com/pythonnet/pythonnet/issues/251