### PR TITLE
Python.NET is compatible with Python 3.7 - 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ implementation of the Python language, you should check out the
 [IronPython][ipy] project, which is in active development.
 
 Python.NET is currently compatible and tested with Python releases
-3.7 - 3.10.
+3.7 - 3.11.
 
 To subscribe to the [Python.NET mailing list][ml] or read the
 [online archives][ml-arch] of the list, see the [mailing list information][ml]


### PR DESCRIPTION
Python.NET 3.0.1 supports Python 3.11, see https://pypi.org/project/pythonnet/3.0.1/